### PR TITLE
Added docs and Windows-specific fixes.

### DIFF
--- a/pysimpledmx.py
+++ b/pysimpledmx.py
@@ -20,6 +20,13 @@ LABELS = {
 
 class DMXConnection(object):
   def __init__(self, comport = None):
+    '''
+    On Windows, the only argument is the port number. On *nix, it's the path to the serial device.
+    For example:
+        DMXConnection(4)              # Windows
+        DMXConnection('/dev/tty2')    # Linux
+        DMXConnection("/dev/ttyUSB0") # Linux
+    '''
     self.dmx_frame = [0] * DMX_SIZE
     try:
       self.com = serial.Serial(comport, baudrate = COM_BAUD, timeout = COM_TIMEOUT)

--- a/pysimpledmx.py
+++ b/pysimpledmx.py
@@ -19,12 +19,12 @@ LABELS = {
 
 
 class DMXConnection(object):
-  def __init__(self, comport=None):
+  def __init__(self, comport = None):
     self.dmx_frame = [0] * DMX_SIZE
     try:
       self.com = serial.Serial(comport, baudrate = COM_BAUD, timeout = COM_TIMEOUT)
     except:
-      com_name = 'COM%s' % comport + 1 if type(comport) == int else comport
+      com_name = 'COM%s' % (comport + 1) if type(comport) == int else comport
       print "Could not open device %s. Quitting application." % com_name
       sys.exit(0)
 
@@ -73,3 +73,4 @@ class DMXConnection(object):
 
   def close(self):
     self.com.close()
+


### PR DESCRIPTION
Sorry about last time. I sent the an unfinished version. This version will exit properly if the port can't be opened on Windows. Also, I added docs for how to open a port on different versions. It took me some time to figure out, so I thought I might as well add it in here.